### PR TITLE
Add collection throttling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,19 +39,22 @@ runtime:
   # timeout for a single call to osqueryi
   timeout: 10s
 
+# prevent collecting metrics multiple times within this interval
+throttle_interval: 10s
+
 metrics:
   counters:
     # a list of counter definitions
-    [ - <counter definition> ... ]  
+    [ - <counter definition> ... ]
   gauges:
     # a list of gauge definitions
-    [ - <gauge definition> ... ]  
+    [ - <gauge definition> ... ]
   countervecs:
     # a list of countervec definitions
-    [ - <countervec definition> ... ]  
+    [ - <countervec definition> ... ]
   gaugevecs:
     # a list of gaugevec definitions
-    [ - <gaugevec definition> ... ]  
+    [ - <gaugevec definition> ... ]
 ```
 There are four types of metrics, that can be exported:
 

--- a/main.go
+++ b/main.go
@@ -5,9 +5,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
 	"gopkg.in/yaml.v2"
-	"github.com/zwopir/osquery_exporter/collector"
-	"github.com/zwopir/osquery_exporter/model"
-	"github.com/zwopir/osquery_exporter/osquery"
+	"osquery_exporter/collector"
+	"osquery_exporter/model"
+	"osquery_exporter/osquery"
 
 	"flag"
 	"io/ioutil"
@@ -44,6 +44,7 @@ func main() {
 	osqueryCollector := collector.NewOsqueryCollector(
 		r,
 		config.Metrics,
+		config.ThrottleInterval,
 	)
 
 	prometheus.MustRegister(osqueryCollector)

--- a/model/model.go
+++ b/model/model.go
@@ -3,6 +3,7 @@ package model
 import (
 	"crypto/md5"
 	"github.com/prometheus/client_golang/prometheus"
+	"sync"
 	"time"
 )
 
@@ -10,8 +11,16 @@ const namespace = "osquery_exporter"
 
 // Config represents a osquery_exporter configuration
 type Config struct {
-	OsQueryRuntime OsQueryRuntime `yaml:"runtime"`
-	Metrics        Metrics        `yaml:"metrics"`
+	OsQueryRuntime   OsQueryRuntime `yaml:"runtime"`
+	Metrics          Metrics        `yaml:"metrics"`
+	ThrottleInterval string         `yaml:"throttle_interval"`
+}
+
+// ThrottleState holds throttle interval configuration and state
+type ThrottleState struct {
+	Lock     sync.Mutex
+	LastRun  time.Time
+	Interval time.Duration
 }
 
 // OsQueryRuntime holds the information for the osquery binary and command invocation

--- a/osquery/osquery.go
+++ b/osquery/osquery.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/prometheus/common/log"
 	"os/exec"
-	"github.com/zwopir/osquery_exporter/model"
+	"osquery_exporter/model"
 	"time"
 )
 


### PR DESCRIPTION
Allow metric collection throttling to reduce load in case of expensive queries.

Example is queries on `systemd_units` (osquery-4.7.0) table are pretty expensive.